### PR TITLE
build: excludes vulnerable log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,21 @@ dependencies {
     implementation 'org.jenkins-ci.plugins:credentials:2.3.15'
     // Use JUnit test framework.
     testImplementation 'junit:junit:4.13.2'
+    // Ensure vulnerable log4j never creeps in
+    constraints {
+        implementation('org.apache.logging.log4j:log4j-core') {
+            version {
+                strictly('[2.16, 3[')
+                prefer('2.16.0')
+            }
+            because('CVE-2021-44228: Log4j vulnerable to remote code execution')
+        }
+    }
 }
 
 changelog {
     from 'v0.2.0'
-} 
+}
 
 scmVersion {
     tag {


### PR DESCRIPTION
This may be overcautious, but I want to make sure the vulnerable log4j never gets into this project.
