### PR TITLE
Fix incorrect nvm existence check

### DIFF
--- a/src/main/java/io/interrogate/npmyarnwrappersteps/plugin/NVMUtilities.java
+++ b/src/main/java/io/interrogate/npmyarnwrappersteps/plugin/NVMUtilities.java
@@ -24,7 +24,7 @@ public class NVMUtilities {
     @SuppressWarnings("OctalInteger")
     public static void install(FilePath workspace, Launcher launcher, TaskListener listener, String nvmInstallerUrl)
             throws IOException, InterruptedException {
-        FilePath home = FilePath.getHomeDirectory(FilePath.localChannel);
+        FilePath home = FilePath.getHomeDirectory(launcher.getChannel() != null ? launcher.getChannel() : FilePath.localChannel);
         if (home.child(".nvm/nvm.sh").exists()) {
             return;
         }


### PR DESCRIPTION
`FilePath.getHomeDirectory(FilePath.localChannel).child(".nvm/nvm.sh").exists()` checks for stuff on the jenkins controller, not build agent where you'd actually want nvm to be installed.

I have tested this on my own jenkins instance. It correctly downloads the nvm if I remove the `~/.nvm` directory, and will not redownload the script once nvm is installed.

I don't have a very good idea on how to setup an automated test for this though. I'm not very familiar with jenkins plugin development in general, so any instructions on how to doing this would be appreciated.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
